### PR TITLE
fix off by 1 error if all lines are blank

### DIFF
--- a/lua/decisive.lua
+++ b/lua/decisive.lua
@@ -61,7 +61,7 @@ local function align_csv(opts)
   local test_line = lines[line]
   -- tolerate a few blank lines at the top of the file (for instance
   -- when pasting a CSV in a new buffer)
-  while #test_line == 0 and line <= #lines do
+  while #test_line == 0 and line < #lines do
     line = line + 1
     test_line = lines[line]
   end


### PR DESCRIPTION
when attempting to align an empty file, align_csv will try to look for a non-blank line, but in doing so it will pull from the lines array using the length + 1, leading to an error:

lua/decisive.lua:64: attempt to get length of local 'test_line' (a nil value)

This is in the context of an autocmd like so:

```lua
vim.api.nvim_create_autocmd('BufWinEnter', {
  pattern = '*.csv',
  callback = function()
    local decisive = require('decisive')
    decisive.setup({})
    decisive.align_csv({ csv_separator = ',' })
  end
})
```

Where the error occurs when that autocmd fires on a new csv buffer that has no content.